### PR TITLE
add command to delete stage locations from disk when merged into master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,5 +29,5 @@ deployment:
         - ssh help@webserver.risevision.com 'mkdir -p /rise-front-end/help';
         - rsync -rptz -e ssh --delete _site help@webserver.risevision.com:/rise-front-end/help;
         - tar czvf dist.tar.gz _site
-        # Clean up stage by removing the branch directory from the server
-        - ssh help@webserver-stage.risevision.com 'rm -rf /rise-front-end/help/$(git log -1 --pretty=%B | grep Merge | sed -e 's/.*from Rise-Vision\///g' | sed 's/\//-/g')';
+        # Clean up stage by moving the branch directory to /tmp (and cleaning at a regular interval)
+        - FILENAME=$(git log -1 --pretty=%B | grep Merge | sed -e 's/.*from Rise-Vision\///g' | sed 's/\//-/g') ; RENAMETIME=$(date +%s) ; ssh help@webserver-stage.risevision.com "if [[ -d /rise-front-end/help/$FILENAME && -n "$FILENAME" ]]; then mv -f /rise-front-end/help/$FILENAME /tmp/$RENAMETIME-$FILENAME; fi"

--- a/circle.yml
+++ b/circle.yml
@@ -29,3 +29,5 @@ deployment:
         - ssh help@webserver.risevision.com 'mkdir -p /rise-front-end/help';
         - rsync -rptz -e ssh --delete _site help@webserver.risevision.com:/rise-front-end/help;
         - tar czvf dist.tar.gz _site
+        # Clean up stage by removing the branch directory from the server
+        - ssh help@webserver-stage.risevision.com 'rm -rf /rise-front-end/help/$(git log -1 --pretty=%B | grep Merge | sed -e 's/.*from Rise-Vision\///g' | sed 's/\//-/g')';


### PR DESCRIPTION
@rodrigopavezi No rush at all, but please review carefully...  There's a bit of danger when "rm -rf" is used.  <grin>

When I tested some of the sed output, I didn't get the results I think we're looking for so I adjusted it slightly:

Original
- ssh help@webserver-stage.risevision.com 'rm -rf /rise-front-end/help/$(git log -1 --pretty=%B | grep Merge | sed -e 's/.from Rise-Vision\/(.).*/\1/g')';

Modified
- ssh help@webserver-stage.risevision.com 'rm -rf /rise-front-end/help/$(git log -1 --pretty=%B | grep Merge | sed -e 's/.*from Rise-Vision\///g' | sed 's/\//-/g')';

Thanks.