### PR TITLE
correct crontab syntax by using system entry and not user entry

### DIFF
--- a/_posts/user/player/chrome-app/2014-10-01-chrome-player-linux.md
+++ b/_posts/user/player/chrome-app/2014-10-01-chrome-player-linux.md
@@ -20,7 +20,7 @@ order: 2
 2. Type sudo gedit /etc/crontab
 3. At the bottom, type 0 3 * * * root /sbin/shutdown -r now
 4. Save and exit.
-5. This will reboot your player at 3AM. If you would like to reboot at a different time, simply replace that with the hour you would prefer.
+5. This will reboot your player at 3AM. If you would like to reboot at a different time, simply replace the 0 and 3 with your choice of minute and hour.
 
 #####Chrome App Player (first run)
 When the Player is launched for the first time you will be warned that the Display ID is not found.

--- a/_posts/user/player/chrome-app/2014-10-01-chrome-player-linux.md
+++ b/_posts/user/player/chrome-app/2014-10-01-chrome-player-linux.md
@@ -17,9 +17,9 @@ order: 2
 
 #####Configure a scheduled reboot
 1. Open terminal
-2. Type sudo crontab -e
-3. Select your editor
-4. At the bottom, type 0 3 * * * root /sbin/shutdown -r now
+2. Type sudo gedit /etc/crontab
+3. At the bottom, type 0 3 * * * root /sbin/shutdown -r now
+4. Save and exit.
 5. This will reboot your player at 3AM. If you would like to reboot at a different time, simply replace that with the hour you would prefer.
 
 #####Chrome App Player (first run)


### PR DESCRIPTION
These changes are staged here.
https://help-stage.risevision.com/doc-change-user-crontab-to-system-crontab/_site/user/player/chrome-app/chrome-player-linux

@AlexKolenoff would you care to review?