### PR TITLE
Redirect User Documentation link to Help Center

### DIFF
--- a/assets/javascript/controllers/ctr-header-navbar.js
+++ b/assets/javascript/controllers/ctr-header-navbar.js
@@ -9,7 +9,7 @@ angular.module("risevision.documentation")
     },
     {
       title: "User Documentation",
-      link: $state.href("user", {}, {absolute: true})
+      link: "https://risevision.zendesk.com"
     },
     {
       title: "Developer Documentation",


### PR DESCRIPTION
@fjvallarino We need to update the internal link to User Documentation in the docs. 
Please review. Thanks!

Stage link: https://help-stage.risevision.com/chore-redirect-user-doc/_site/developer