### PR TITLE
Include company id for Apps get

### DIFF
--- a/assets/dev-hub/scripts/apps/controllers/ctr-app-management.js
+++ b/assets/dev-hub/scripts/apps/controllers/ctr-app-management.js
@@ -35,7 +35,7 @@ angular.module("risevision.developer.hub")
 
         var getApps = function(selectedCompanyId) {
             //$loading.start("rv-dev-hub-apps-loader");
-            var listAppsResult = listApps()
+            var listAppsResult = listApps(selectedCompanyId)
                 .then(function (apps) {
                     $scope.apps = apps;
                     getCompleteApp();

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "tests"
   ],
   "dependencies": {
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.3.0",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.3.5",
     "lunr.js": "0.5.5",
     "date.format": "1.2.3",
     "uri.js": "1.14.1",


### PR DESCRIPTION
Currently, seeing Client Ids added to a Sub-Company is not working. This fixes it.

Also updating CH since I'm making this change.

@Rise-Vision/apps please review.

Thanks!